### PR TITLE
Extract version info from runtime/debug

### DIFF
--- a/cmd/gocroissant/main.go
+++ b/cmd/gocroissant/main.go
@@ -33,8 +33,10 @@ Croissant is a standardized way to describe machine learning datasets using JSON
 		Long:  `Print the version, git hash, and build time information of the gocroissant tool.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("%s version %s\n", version.AppName, version.Version)
-			fmt.Printf("Git commit: %s\n", version.GitHash)
-			fmt.Printf("Built on: %s\n", version.BuildTime)
+			stamp := version.RetrieveStamp()
+			fmt.Printf("  Built with %s on %s\n", stamp.InfoGoCompiler, stamp.InfoBuildTime)
+			fmt.Printf("  Git ref: %s\n", stamp.VCSRevision)
+			fmt.Printf("  Go version %s, GOOS %s, GOARCH %s\n", stamp.InfoGoVersion, stamp.InfoGOOS, stamp.InfoGOARCH)
 		},
 	}
 	rootCmd.AddCommand(versionCmd)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,5 +1,11 @@
 package version
 
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+)
+
 // These variables should be set at compile time
 var (
 	// AppName is the name of the application
@@ -14,3 +20,40 @@ var (
 	// BuildTime build time in RFC3339 format
 	BuildTime = "now"
 )
+
+type Stamp struct {
+	InfoGoVersion  string
+	InfoGoCompiler string
+	InfoGOARCH     string
+	InfoGOOS       string
+	InfoBuildTime  string
+	VCSRevision    string
+}
+
+func RetrieveStamp() *Stamp {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		fmt.Printf("Error: could not read build info")
+		os.Exit(1)
+	}
+	//nolint:exhaustruct
+	stamp := Stamp{}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "info.goVersion":
+			stamp.InfoGoVersion = setting.Value
+		case "-compiler":
+			stamp.InfoGoCompiler = setting.Value
+		case "GOARCH":
+			stamp.InfoGOARCH = setting.Value
+		case "GOOS":
+			stamp.InfoGOOS = setting.Value
+		case "vcs.time":
+			stamp.InfoBuildTime = setting.Value
+		case "vcs.revision":
+			stamp.VCSRevision = setting.Value
+		}
+	}
+
+	return &stamp
+}


### PR DESCRIPTION
This extracts version and compile-time information from the runtime instead of needing to be set manually through env+compile flags.