### PR TITLE
Add some starter unit tests

### DIFF
--- a/pkg/croissant/croissant_test.go
+++ b/pkg/croissant/croissant_test.go
@@ -1,5 +1,4 @@
 // File: pkg/croissant/croissant_test.go
-
 package croissant
 
 import (

--- a/pkg/croissant/croissant_test.go
+++ b/pkg/croissant/croissant_test.go
@@ -1,0 +1,99 @@
+// File: pkg/croissant/croissant_test.go
+
+package croissant
+
+import (
+	"testing"
+)
+
+// TestInferDataType tests the InferDataType function for various types.
+func TestInferDataType(t *testing.T) {
+	cases := []struct {
+		val      string
+		expected string
+	}{
+		{"true", "sc:Boolean"},
+		{"false", "sc:Boolean"},
+		{"123", "sc:Integer"},
+		{"-456", "sc:Integer"},
+		{"3.14", "sc:Number"},
+		{"2.5e10", "sc:Number"},
+		{"2023-01-01", "sc:DateTime"},
+		{"01/15/2023", "sc:DateTime"},
+		{"https://example.com", "sc:URL"},
+		{"http://foo.org", "sc:URL"},
+		{"test@example.com", "sc:Text"},
+		{"foo bar", "sc:Text"},
+		{"", "sc:Text"},
+	}
+	for _, c := range cases {
+		got := InferDataType(c.val)
+		if got != c.expected {
+			t.Errorf("InferDataType(%q) = %q, want %q", c.val, got, c.expected)
+		}
+	}
+}
+
+// TestIsValidDataType tests the IsValidDataType function.
+func TestIsValidDataType(t *testing.T) {
+	valid := []string{
+		"sc:Text", "sc:Boolean", "sc:Integer", "sc:Number", "sc:DateTime", "sc:URL",
+		"sc:ImageObject", "sc:VideoObject", "sc:Enumeration", "sc:GeoShape", "sc:GeoCoordinates",
+		"cr:Label", "cr:Split", "cr:BoundingBox", "cr:SegmentationMask",
+		"cr:TrainingSplit", "cr:ValidationSplit", "cr:TestSplit",
+		"wd:Q123", // Wikidata
+	}
+	for _, typ := range valid {
+		if !IsValidDataType(typ) {
+			t.Errorf("IsValidDataType(%q) = false, want true", typ)
+		}
+	}
+	invalid := []string{"sc:Foo", "bar", "wd:X123"}
+	for _, typ := range invalid {
+		if IsValidDataType(typ) {
+			t.Errorf("IsValidDataType(%q) = true, want false", typ)
+		}
+	}
+}
+
+// TestInferSemanticDataType tests basic semantic inference.
+func TestInferSemanticDataType(t *testing.T) {
+	labelFields := []string{"label", "Label", "category", "target", "annotation"}
+	for _, field := range labelFields {
+		types := InferSemanticDataType(field, "cat", nil)
+		if len(types) < 2 || types[1] != "cr:Label" {
+			t.Errorf("InferSemanticDataType(%q, \"cat\") should include cr:Label, got %#v", field, types)
+		}
+	}
+	if types := InferSemanticDataType("split", "train", nil); len(types) < 2 || types[0] != "cr:Split" {
+		t.Errorf("InferSemanticDataType(\"split\", \"train\") should include cr:Split, got %#v", types)
+	}
+	if types := InferSemanticDataType("bbox", "10,20,30,40", nil); types[0] != "cr:BoundingBox" {
+		t.Errorf("InferSemanticDataType(\"bbox\", ...) should be cr:BoundingBox, got %#v", types)
+	}
+	// enum context
+	ctx := map[string]interface{}{"enumValues": []string{"a", "b"}}
+	if types := InferSemanticDataType("foo", "a", ctx); types[0] != "sc:Enumeration" {
+		t.Errorf("InferSemanticDataType(..., \"a\", ctx) should include sc:Enumeration, got %#v", types)
+	}
+}
+
+// TestCleanFieldName
+func TestCleanFieldName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"foo bar", "foo_bar"},
+		{"foo-bar", "foo_bar"},
+		{" foo ", "foo"},
+		{"foo__bar", "foo_bar"},
+		{"123abc", "field_123abc"},
+		{"a!@#b", "a_b"},
+	}
+	for _, c := range cases {
+		got := cleanFieldName(c.in)
+		if got != c.want {
+			t.Errorf("cleanFieldName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/pkg/croissant/testdata/1.0/bad/invalid_references.jsonld
+++ b/pkg/croissant/testdata/1.0/bad/invalid_references.jsonld
@@ -1,0 +1,80 @@
+{
+    "@context": {
+        "@language": "en",
+        "@vocab": "https://schema.org/",
+        "citeAs": "cr:citeAs",
+        "column": "cr:column",
+        "conformsTo": "dct:conformsTo",
+        "cr": "http://mlcommons.org/croissant/",
+        "data": {
+            "@id": "cr:data",
+            "@type": "@json"
+        },
+        "dataType": {
+            "@id": "cr:dataType",
+            "@type": "@vocab"
+        },
+        "dct": "http://purl.org/dc/terms/",
+        "extract": "cr:extract",
+        "field": "cr:field",
+        "fileObject": "cr:fileObject",
+        "fileProperty": "cr:fileProperty",
+        "sc": "https://schema.org/",
+        "source": "cr:source"
+    },
+    "@type": "sc:Dataset",
+    "name": "mydataset",
+    "description": "This is a description.",
+    "conformsTo": "http://mlcommons.org/croissant/1.0",
+    "datePublished": "1990-02-01",
+    "version": "1.0.0",
+    "distribution": [
+        {
+            "@id": "a-csv-table",
+            "@type": "sc:WRONG_TYPE",
+            "name": "a-csv-table",
+            "contentSize": "117743 B",
+            "contentUrl": "https://www.google.com/data.csv",
+            "encodingFormat": "text/csv",
+            "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
+        }
+    ],
+    "recordSet": [
+        {
+            "@id": "a-record-set",
+            "@type": "cr:RecordSet",
+            "name": "a-record-set",
+            "description": "This is a record set.",
+            "field": [
+                {
+                    "@id": "a-record-set/first-field",
+                    "@type": "cr:Field",
+                    "name": "first-field",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "extract": {
+                            "column": "a-column"
+                        },
+                        "fileObject": {
+                            "@id": "NON_EXISTENT_TABLE"
+                        }
+                    }
+                },
+                {
+                    "@id": "a-record-set/second-field",
+                    "@type": "cr:Field",
+                    "name": "second-field",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "extract": {
+                            "column": "another-column"
+                        },
+                        "fileObject": {
+                            "@id": "a-csv-table"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/pkg/croissant/testdata/1.0/bad/missing_fields.jsonld
+++ b/pkg/croissant/testdata/1.0/bad/missing_fields.jsonld
@@ -1,0 +1,64 @@
+{
+    "@context": {
+        "@language": "en",
+        "@vocab": "https://schema.org/",
+        "citeAs": "cr:citeAs",
+        "column": "cr:column",
+        "conformsTo": "dct:conformsTo",
+        "cr": "http://mlcommons.org/croissant/",
+        "data": {
+            "@id": "cr:data",
+            "@type": "@json"
+        },
+        "dataType": {
+            "@id": "cr:dataType",
+            "@type": "@vocab"
+        },
+        "dct": "http://purl.org/dc/terms/",
+        "extract": "cr:extract",
+        "field": "cr:field",
+        "fileObject": "cr:fileObject",
+        "fileProperty": "cr:fileProperty",
+        "format": "cr:format",
+        "sc": "https://schema.org/",
+        "source": "cr:source"
+    },
+    "@type": "sc:WRONG_TYPE",
+    "name": "mydataset",
+    "description": "This is a description.",
+    "datePublished": "1990-02-01",
+    "version": "1.0.0",
+    "distribution": [
+        {
+            "@id": "a-csv-table",
+            "@type": "cr:FileObject",
+            "name": "a-csv-table",
+            "contentSize": "117743 B",
+            "encodingFormat": "text/csv",
+            "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
+        }
+    ],
+    "recordSet": [
+        {
+            "@id": "a-record-set",
+            "@type": "cr:RecordSet",
+            "name": "a-record-set",
+            "description": "This is a record set.",
+            "field": [
+                {
+                    "@id": "a-record-set/first-field",
+                    "@type": "cr:Field",
+                    "name": "first-field",
+                    "source": {
+                        "extract": {
+                            "column": "a-column"
+                        },
+                        "fileObject": {
+                            "@id": "a-csv-table"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/pkg/croissant/testdata/1.0/bad/missing_sha.jsonld
+++ b/pkg/croissant/testdata/1.0/bad/missing_sha.jsonld
@@ -1,0 +1,178 @@
+{
+    "@context": {
+        "@language": "en",
+        "@vocab": "https://schema.org/",
+        "citeAs": "cr:citeAs",
+        "column": "cr:column",
+        "conformsTo": "dct:conformsTo",
+        "cr": "http://mlcommons.org/croissant/",
+        "dct": "http://purl.org/dc/terms/",
+        "data": {
+            "@id": "cr:data",
+            "@type": "@json"
+        },
+        "dataType": {
+            "@id": "cr:dataType",
+            "@type": "@vocab"
+        },
+        "examples": {
+            "@id": "cr:examples",
+            "@type": "@json"
+        },
+        "extract": "cr:extract",
+        "field": "cr:field",
+        "fileObject": "cr:fileObject",
+        "fileProperty": "cr:fileProperty",
+        "fileSet": "cr:fileSet",
+        "format": "cr:format",
+        "includes": "cr:includes",
+        "isLiveDataset": "cr:isLiveDataset",
+        "jsonPath": "cr:jsonPath",
+        "key": "cr:key",
+        "md5": "cr:md5",
+        "parentField": "cr:parentField",
+        "path": "cr:path",
+        "recordSet": "cr:recordSet",
+        "references": "cr:references",
+        "regex": "cr:regex",
+        "repeated": "cr:repeated",
+        "replace": "cr:replace",
+        "sc": "https://schema.org/",
+        "separator": "cr:separator",
+        "source": "cr:source",
+        "subField": "cr:subField",
+        "transform": "cr:transform"
+    },
+    "@type": "sc:Dataset",
+    "name": "Swiss Water Quality Monitoring Dataset",
+    "description": "Environmental monitoring data from major Swiss rivers including water flow rates, precipitation, and turbidity measurements collected across Limmat, Rhine, Reuss, Aare, and Rhône rivers from April 2025.",
+    "conformsTo": "http://mlcommons.org/croissant/1.0",
+    "citeAs": "Swiss Water Quality Monitoring Dataset (2025). Environmental measurements from Swiss river systems.",
+    "creator": {
+        "@type": "Organization",
+        "name": "Swiss Water Monitoring Authority"
+    },
+    "datePublished": "2025-04-15",
+    "version": "1.0.0",
+    "license": "CC-BY-4.0",
+    "keywords": [
+        "water quality",
+        "environmental monitoring",
+        "swiss rivers",
+        "turbidity",
+        "precipitation"
+    ],
+    "url": "https://example.com/water-monitoring-dataset",
+    "distribution": [
+        {
+            "@id": "water_monitoring_data.csv",
+            "@type": "cr:FileObject",
+            "name": "water_monitoring_data.csv",
+            "description": "CSV file containing water monitoring measurements",
+            "contentSize": "1024",
+            "contentUrl": "water_monitoring_data.csv",
+            "encodingFormat": "text/csv",
+            "sha256": "placeholder-hash-calculate-from-actual-file"
+        }
+    ],
+    "recordSet": [
+        {
+            "@id": "water_measurements",
+            "@type": "cr:RecordSet",
+            "name": "water_measurements",
+            "description": "Water quality and flow measurements from Swiss rivers",
+            "field": [
+                {
+                    "@id": "water_measurements/transaction_id",
+                    "@type": "cr:Field",
+                    "name": "transaction_id",
+                    "description": "Unique identifier for each measurement transaction",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "fileObject": {
+                            "@id": "water_monitoring_data.csv"
+                        },
+                        "extract": {
+                            "column": "transaction_id"
+                        }
+                    }
+                },
+                {
+                    "@id": "water_measurements/timestamp",
+                    "@type": "cr:Field",
+                    "name": "timestamp",
+                    "description": "Date and time when the measurement was taken (YYYY-MM-DD HH:MM:SS)",
+                    "dataType": "sc:DateTime",
+                    "source": {
+                        "fileObject": {
+                            "@id": "water_monitoring_data.csv"
+                        },
+                        "extract": {
+                            "column": "timestamp"
+                        }
+                    }
+                },
+                {
+                    "@id": "water_measurements/location",
+                    "@type": "cr:Field",
+                    "name": "location",
+                    "description": "Name of the Swiss river where measurement was taken",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "fileObject": {
+                            "@id": "water_monitoring_data.csv"
+                        },
+                        "extract": {
+                            "column": "location"
+                        }
+                    }
+                },
+                {
+                    "@id": "water_measurements/water_flow_rate",
+                    "@type": "cr:Field",
+                    "name": "water_flow_rate",
+                    "description": "Water flow rate measurement in cubic meters per second",
+                    "dataType": "sc:Float",
+                    "source": {
+                        "fileObject": {
+                            "@id": "water_monitoring_data.csv"
+                        },
+                        "extract": {
+                            "column": "water_flow_rate"
+                        }
+                    }
+                },
+                {
+                    "@id": "water_measurements/precipitation",
+                    "@type": "cr:Field",
+                    "name": "precipitation",
+                    "description": "Precipitation measurement in millimeters",
+                    "dataType": "sc:Float",
+                    "source": {
+                        "fileObject": {
+                            "@id": "water_monitoring_data.csv"
+                        },
+                        "extract": {
+                            "column": "precipitation"
+                        }
+                    }
+                },
+                {
+                    "@id": "water_measurements/turbidity",
+                    "@type": "cr:Field",
+                    "name": "turbidity",
+                    "description": "Water turbidity measurement in NTU (Nephelometric Turbidity Units)",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "fileObject": {
+                            "@id": "water_monitoring_data.csv"
+                        },
+                        "extract": {
+                            "column": "turbidity"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/pkg/croissant/testdata/1.0/good/coco2014-mini.jsonld
+++ b/pkg/croissant/testdata/1.0/good/coco2014-mini.jsonld
@@ -1,0 +1,353 @@
+{
+    "@context": {
+        "@language": "en",
+        "@vocab": "https://schema.org/",
+        "citeAs": "cr:citeAs",
+        "column": "cr:column",
+        "conformsTo": "dct:conformsTo",
+        "cr": "http://mlcommons.org/croissant/",
+        "rai": "http://mlcommons.org/croissant/RAI/",
+        "data": {
+            "@id": "cr:data",
+            "@type": "@json"
+        },
+        "dataType": {
+            "@id": "cr:dataType",
+            "@type": "@vocab"
+        },
+        "dct": "http://purl.org/dc/terms/",
+        "examples": {
+            "@id": "cr:examples",
+            "@type": "@json"
+        },
+        "extract": "cr:extract",
+        "field": "cr:field",
+        "fileProperty": "cr:fileProperty",
+        "fileObject": "cr:fileObject",
+        "fileSet": "cr:fileSet",
+        "format": "cr:format",
+        "includes": "cr:includes",
+        "isLiveDataset": "cr:isLiveDataset",
+        "jsonPath": "cr:jsonPath",
+        "key": "cr:key",
+        "md5": "cr:md5",
+        "parentField": "cr:parentField",
+        "path": "cr:path",
+        "recordSet": "cr:recordSet",
+        "references": "cr:references",
+        "regex": "cr:regex",
+        "repeated": "cr:repeated",
+        "replace": "cr:replace",
+        "sc": "https://schema.org/",
+        "separator": "cr:separator",
+        "source": "cr:source",
+        "subField": "cr:subField",
+        "transform": "cr:transform",
+        "wd": "https://www.wikidata.org/wiki/"
+    },
+    "@type": "sc:Dataset",
+    "name": "Mini-COCO",
+    "description": "Smaller downloadable version of COCO to be used in unit tests.",
+    "conformsTo": "http://mlcommons.org/croissant/1.0",
+    "citeAs": "None",
+    "license": "cc-by-4.0",
+    "url": "None",
+    "version": "1.0.0",
+    "distribution": [
+        {
+            "@type": "cr:FileObject",
+            "@id": "train2014.zip",
+            "name": "train2014.zip",
+            "contentSize": " B",
+            "contentUrl": "data/train2014.zip",
+            "encodingFormat": "application/zip",
+            "sha256": "d010037fee9416bdcc187a37a4aec7bef798316147da2753bd86e78fc0d469a5"
+        },
+        {
+            "@type": "cr:FileSet",
+            "@id": "image-files",
+            "name": "image-files",
+            "containedIn": {
+                "@id": "train2014.zip"
+            },
+            "encodingFormat": "image/jpeg",
+            "includes": "*.jpg"
+        },
+        {
+            "@type": "cr:FileObject",
+            "@id": "caption_annotations-files",
+            "name": "caption_annotations-files",
+            "contentSize": " B",
+            "contentUrl": "data/captions_train2014.json",
+            "encodingFormat": "application/json",
+            "sha256": "6f3755cb987413021018525cbb4c484d696ff41269e6b0b43c5f63eaf576e09f"
+        },
+        {
+            "@type": "cr:FileObject",
+            "@id": "bbox_annotations-files",
+            "name": "bbox_annotations-files",
+            "contentUrl": "data/instances_train2014.json",
+            "encodingFormat": "application/json",
+            "sha256": "df2760cf1d55e37b9cde91499286a3cac52efc31d95a9d21ba34dbbbcf693654"
+        }
+    ],
+    "recordSet": [
+        {
+            "@type": "cr:RecordSet",
+            "@id": "split_enums",
+            "name": "split_enums",
+            "description": "Maps split names to semantic values.",
+            "key": {
+                "@id": "name"
+            },
+            "field": [
+                {
+                    "@type": "cr:Field",
+                    "@id": "split_enums/name",
+                    "name": "split_enums/name",
+                    "description": "One of: train, val, test.",
+                    "dataType": "sc:Text"
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "split_enums/url",
+                    "name": "split_enums/url",
+                    "description": "Corresponding mlcommons.org definition URL",
+                    "dataType": [
+                        "wd:Q3985153",
+                        "sc:URL"
+                    ]
+                }
+            ],
+            "data": [
+                {
+                    "split_enums/name": "train",
+                    "split_enums/url": "https://mlcommons.org/definitions/training_split"
+                },
+                {
+                    "split_enums/name": "val",
+                    "split_enums/url": "https://mlcommons.org/definitions/validation_split"
+                },
+                {
+                    "split_enums/name": "test",
+                    "split_enums/url": "https://mlcommons.org/definitions/test_split"
+                }
+            ]
+        },
+        {
+            "@type": "cr:RecordSet",
+            "@id": "images",
+            "name": "images",
+            "key": {
+                "@id": "img_id"
+            },
+            "field": [
+                {
+                    "@type": "cr:Field",
+                    "@id": "images/image_filename",
+                    "name": "images/image_filename",
+                    "description": "The filename of the image. eg: COCO_train2014_000000000003.jpg",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "fileSet": {
+                            "@id": "image-files"
+                        },
+                        "extract": {
+                            "fileProperty": "filename"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "images/image_content",
+                    "name": "images/image_content",
+                    "description": "The content of the image.",
+                    "dataType": "sc:ImageObject",
+                    "source": {
+                        "fileSet": {
+                            "@id": "image-files"
+                        },
+                        "extract": {
+                            "fileProperty": "content"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "images/split",
+                    "name": "images/split",
+                    "dataType": [
+                        "wd:Q3985153",
+                        "sc:Text"
+                    ],
+                    "references": {
+                        "field": {
+                            "@id": "split_enums/name"
+                        }
+                    },
+                    "source": {
+                        "fileSet": {
+                            "@id": "image-files"
+                        },
+                        "extract": {
+                            "fileProperty": "fullpath"
+                        },
+                        "transform": {
+                            "regex": "^(train|val|test)2014/.*\\.jpg$"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "@type": "cr:RecordSet",
+            "@id": "captions",
+            "name": "captions",
+            "key": {
+                "@id": "id"
+            },
+            "field": [
+                {
+                    "@type": "cr:Field",
+                    "@id": "captions/id",
+                    "name": "captions/id",
+                    "description": "The ID of the caption",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "fileObject": {
+                            "@id": "caption_annotations-files"
+                        },
+                        "extract": {
+                            "jsonPath": "$.annotations[*].id"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "captions/image_id",
+                    "name": "captions/image_id",
+                    "description": "The ID of the image",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "fileObject": {
+                            "@id": "caption_annotations-files"
+                        },
+                        "extract": {
+                            "jsonPath": "$.annotations[*].image_id"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "captions/caption",
+                    "name": "captions/caption",
+                    "description": "The caption",
+                    "dataType": [
+                        "wd:Q18585177",
+                        "sc:Text"
+                    ],
+                    "source": {
+                        "fileObject": {
+                            "@id": "caption_annotations-files"
+                        },
+                        "extract": {
+                            "jsonPath": "$.annotations[*].caption"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "captions/split",
+                    "name": "captions/split",
+                    "dataType": [
+                        "wd:Q3985153",
+                        "sc:Text"
+                    ],
+                    "references": {
+                        "field": {
+                            "@id": "split_enums/name"
+                        }
+                    },
+                    "source": {
+                        "fileObject": {
+                            "@id": "caption_annotations-files"
+                        },
+                        "extract": {
+                            "fileProperty": "filename"
+                        },
+                        "transform": {
+                            "regex": ".*_(val|train)2014\\.json$"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "@type": "cr:RecordSet",
+            "@id": "bounding_boxes",
+            "name": "bounding_boxes",
+            "field": [
+                {
+                    "@type": "cr:Field",
+                    "@id": "bounding_boxes/id",
+                    "name": "bounding_boxes/id",
+                    "description": "The ID of the annotation.",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "fileObject": {
+                            "@id": "bbox_annotations-files"
+                        },
+                        "extract": {
+                            "jsonPath": "$.annotations[*].id"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "bounding_boxes/image_id",
+                    "name": "bounding_boxes/image_id",
+                    "description": "The ID of the image.",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "fileObject": {
+                            "@id": "bbox_annotations-files"
+                        },
+                        "extract": {
+                            "jsonPath": "$.annotations[*].image_id"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "bounding_boxes/bbox",
+                    "name": "bounding_boxes/bbox",
+                    "description": "The bounding box on the image.",
+                    "dataType": "cr:BoundingBox",
+                    "source": {
+                        "fileObject": {
+                            "@id": "bbox_annotations-files"
+                        },
+                        "extract": {
+                            "jsonPath": "$.annotations[*].bbox"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "bounding_boxes/area",
+                    "name": "bounding_boxes/area",
+                    "description": "The area of the bounding box.",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "fileObject": {
+                            "@id": "bbox_annotations-files"
+                        },
+                        "extract": {
+                            "jsonPath": "$.annotations[*].area"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/pkg/croissant/testdata/1.0/good/ok1.jsonld
+++ b/pkg/croissant/testdata/1.0/good/ok1.jsonld
@@ -1,0 +1,142 @@
+{
+  "@context": {
+    "@language": "en",
+    "@vocab": "https://schema.org/",
+    "citeAs": "cr:citeAs",
+    "column": "cr:column",
+    "conformsTo": "dct:conformsTo",
+    "cr": "http://mlcommons.org/croissant/",
+    "dct": "http://purl.org/dc/terms/",
+    "data": {
+      "@id": "cr:data",
+      "@type": "@json"
+    },
+    "dataType": {
+      "@id": "cr:dataType",
+      "@type": "@vocab"
+    },
+    "extract": "cr:extract",
+    "field": "cr:field",
+    "fileObject": "cr:fileObject",
+    "fileProperty": "cr:fileProperty",
+    "sc": "https://schema.org/",
+    "source": "cr:source"
+  },
+  "@type": "sc:Dataset",
+  "name": "data_dataset",
+  "description": "Dataset created from data.csv",
+  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "datePublished": "2025-05-14",
+  "version": "1.0.0",
+  "distribution": [
+    {
+      "@id": "data.csv",
+      "@type": "cr:FileObject",
+      "name": "data.csv",
+      "contentSize": "892 B",
+      "contentUrl": "data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "e34c89d62c0d2b39c8663a18f53c054adc6930436dac9ec5a1a837fd9e83ce60"
+    }
+  ],
+  "recordSet": [
+    {
+      "@id": "main",
+      "@type": "cr:RecordSet",
+      "name": "main",
+      "description": "Records from data.csv",
+      "field": [
+        {
+          "@id": "main/transaction_id",
+          "@type": "cr:Field",
+          "name": "transaction_id",
+          "description": "Field for transaction_id",
+          "dataType": "sc:Integer",
+          "source": {
+            "extract": {
+              "column": "transaction_id"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/timestamp",
+          "@type": "cr:Field",
+          "name": "timestamp",
+          "description": "Field for timestamp",
+          "dataType": "sc:Text",
+          "source": {
+            "extract": {
+              "column": "timestamp"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/location",
+          "@type": "cr:Field",
+          "name": "location",
+          "description": "Field for location",
+          "dataType": "sc:Text",
+          "source": {
+            "extract": {
+              "column": "location"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/water_flow_rate",
+          "@type": "cr:Field",
+          "name": "water_flow_rate",
+          "description": "Field for water_flow_rate",
+          "dataType": "sc:Float",
+          "source": {
+            "extract": {
+              "column": "water_flow_rate"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/precipitation",
+          "@type": "cr:Field",
+          "name": "precipitation",
+          "description": "Field for precipitation",
+          "dataType": "sc:Float",
+          "source": {
+            "extract": {
+              "column": "precipitation"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/turbidity",
+          "@type": "cr:Field",
+          "name": "turbidity",
+          "description": "Field for turbidity",
+          "dataType": "sc:Integer",
+          "source": {
+            "extract": {
+              "column": "turbidity"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/croissant/testdata/1.0/good/ok2.jsonld
+++ b/pkg/croissant/testdata/1.0/good/ok2.jsonld
@@ -1,0 +1,164 @@
+{
+  "@context": {
+    "@language": "en",
+    "@vocab": "https://schema.org/",
+    "citeAs": "cr:citeAs",
+    "column": "cr:column",
+    "conformsTo": "dct:conformsTo",
+    "cr": "http://mlcommons.org/croissant/",
+    "dct": "http://purl.org/dc/terms/",
+    "rai": "http://mlcommons.org/croissant/RAI/",
+    "data": {
+      "@id": "cr:data",
+      "@type": "@json"
+    },
+    "dataType": {
+      "@id": "cr:dataType",
+      "@type": "@vocab"
+    },
+    "examples": {
+      "@id": "cr:examples",
+      "@type": "@json"
+    },
+    "extract": "cr:extract",
+    "field": "cr:field",
+    "fileObject": "cr:fileObject",
+    "fileProperty": "cr:fileProperty",
+    "fileSet": "cr:fileSet",
+    "format": "cr:format",
+    "includes": "cr:includes",
+    "isLiveDataset": "cr:isLiveDataset",
+    "jsonPath": "cr:jsonPath",
+    "key": "cr:key",
+    "md5": "cr:md5",
+    "parentField": "cr:parentField",
+    "path": "cr:path",
+    "recordSet": "cr:recordSet",
+    "references": "cr:references",
+    "regex": "cr:regex",
+    "repeated": "cr:repeated",
+    "replace": "cr:replace",
+    "sc": "https://schema.org/",
+    "separator": "cr:separator",
+    "source": "cr:source",
+    "subField": "cr:subField",
+    "transform": "cr:transform"
+  },
+  "@type": "sc:Dataset",
+  "name": "data_dataset",
+  "description": "Dataset created from data.csv",
+  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "datePublished": "2025-09-22",
+  "version": "1.0.0",
+  "distribution": [
+    {
+      "@id": "data.csv",
+      "@type": "cr:FileObject",
+      "name": "data.csv",
+      "contentSize": "892 B",
+      "contentUrl": "data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "e34c89d62c0d2b39c8663a18f53c054adc6930436dac9ec5a1a837fd9e83ce60"
+    }
+  ],
+  "recordSet": [
+    {
+      "@id": "main",
+      "@type": "cr:RecordSet",
+      "name": "main",
+      "description": "Records from data.csv",
+      "field": [
+        {
+          "@id": "main/transaction_id",
+          "@type": "cr:Field",
+          "name": "transaction_id",
+          "description": "Field for transaction_id",
+          "dataType": "sc:Integer",
+          "source": {
+            "extract": {
+              "column": "transaction_id"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/timestamp",
+          "@type": "cr:Field",
+          "name": "timestamp",
+          "description": "Field for timestamp",
+          "dataType": "sc:Text",
+          "source": {
+            "extract": {
+              "column": "timestamp"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/location",
+          "@type": "cr:Field",
+          "name": "location",
+          "description": "Field for location",
+          "dataType": "sc:Text",
+          "source": {
+            "extract": {
+              "column": "location"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/water_flow_rate",
+          "@type": "cr:Field",
+          "name": "water_flow_rate",
+          "description": "Field for water_flow_rate",
+          "dataType": "sc:Number",
+          "source": {
+            "extract": {
+              "column": "water_flow_rate"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/precipitation",
+          "@type": "cr:Field",
+          "name": "precipitation",
+          "description": "Field for precipitation",
+          "dataType": "sc:Number",
+          "source": {
+            "extract": {
+              "column": "precipitation"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/turbidity",
+          "@type": "cr:Field",
+          "name": "turbidity",
+          "description": "Field for turbidity",
+          "dataType": "sc:Integer",
+          "source": {
+            "extract": {
+              "column": "turbidity"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/croissant/testdata/1.0/good/ok3.jsonld
+++ b/pkg/croissant/testdata/1.0/good/ok3.jsonld
@@ -1,0 +1,142 @@
+{
+  "@context": {
+    "@language": "en",
+    "@vocab": "https://schema.org/",
+    "citeAs": "cr:citeAs",
+    "column": "cr:column",
+    "conformsTo": "dct:conformsTo",
+    "cr": "http://mlcommons.org/croissant/",
+    "dct": "http://purl.org/dc/terms/",
+    "data": {
+      "@id": "cr:data",
+      "@type": "@json"
+    },
+    "dataType": {
+      "@id": "cr:dataType",
+      "@type": "@vocab"
+    },
+    "extract": "cr:extract",
+    "field": "cr:field",
+    "fileObject": "cr:fileObject",
+    "fileProperty": "cr:fileProperty",
+    "sc": "https://schema.org/",
+    "source": "cr:source"
+  },
+  "@type": "sc:Dataset",
+  "name": "data_dataset",
+  "description": "Dataset created from data.csv",
+  "conformsTo": "http://mlcommons.org/croissant/1.0",
+  "datePublished": "2025-05-14",
+  "version": "1.0.0",
+  "distribution": [
+    {
+      "@id": "data.csv",
+      "@type": "cr:FileObject",
+      "name": "data.csv",
+      "contentSize": "892 B",
+      "contentUrl": "data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "e34c89d62c0d2b39c8663a18f53c054adc6930436dac9ec5a1a837fd9e83ce60"
+    }
+  ],
+  "recordSet": [
+    {
+      "@id": "main",
+      "@type": "cr:RecordSet",
+      "name": "main",
+      "description": "Records from data.csv",
+      "field": [
+        {
+          "@id": "main/transaction_id",
+          "@type": "cr:Field",
+          "name": "transaction_id",
+          "description": "Field for transaction_id",
+          "dataType": "sc:Integer",
+          "source": {
+            "extract": {
+              "column": "transaction_id"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/timestamp",
+          "@type": "cr:Field",
+          "name": "timestamp",
+          "description": "Field for timestamp",
+          "dataType": "sc:Text",
+          "source": {
+            "extract": {
+              "column": "timestamp"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/location",
+          "@type": "cr:Field",
+          "name": "location",
+          "description": "Field for location",
+          "dataType": "sc:Text",
+          "source": {
+            "extract": {
+              "column": "location"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/water_flow_rate",
+          "@type": "cr:Field",
+          "name": "water_flow_rate",
+          "description": "Field for water_flow_rate",
+          "dataType": "sc:Float",
+          "source": {
+            "extract": {
+              "column": "water_flow_rate"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/precipitation",
+          "@type": "cr:Field",
+          "name": "precipitation",
+          "description": "Field for precipitation",
+          "dataType": "sc:Float",
+          "source": {
+            "extract": {
+              "column": "precipitation"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        },
+        {
+          "@id": "main/turbidity",
+          "@type": "cr:Field",
+          "name": "turbidity",
+          "description": "Field for turbidity",
+          "dataType": "sc:Integer",
+          "source": {
+            "extract": {
+              "column": "turbidity"
+            },
+            "fileObject": {
+              "@id": "data.csv"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/croissant/testdata/1.0/good/simple_parquet.jsonld
+++ b/pkg/croissant/testdata/1.0/good/simple_parquet.jsonld
@@ -1,0 +1,86 @@
+{
+    "@context": {
+        "@language": "en",
+        "@vocab": "https://schema.org/",
+        "column": "ml:column",
+        "data": {
+            "@id": "ml:data",
+            "@type": "@json"
+        },
+        "dataBiases": "ml:dataBiases",
+        "dataCollection": "ml:dataCollection",
+        "dataType": {
+            "@id": "ml:dataType",
+            "@type": "@vocab"
+        },
+        "dct": "http://purl.org/dc/terms/",
+        "extract": "ml:extract",
+        "field": "ml:field",
+        "fileProperty": "ml:fileProperty",
+        "format": "ml:format",
+        "includes": "ml:includes",
+        "isEnumeration": "ml:isEnumeration",
+        "jsonPath": "ml:jsonPath",
+        "ml": "http://mlcommons.org/schema/",
+        "parentField": "ml:parentField",
+        "path": "ml:path",
+        "personalSensitiveInformation": "ml:personalSensitiveInformation",
+        "recordSet": "ml:recordSet",
+        "references": "ml:references",
+        "regex": "ml:regex",
+        "repeated": "ml:repeated",
+        "replace": "ml:replace",
+        "sc": "https://schema.org/",
+        "separator": "ml:separator",
+        "source": "ml:source",
+        "subField": "ml:subField",
+        "transform": "ml:transform"
+    },
+    "@type": "sc:Dataset",
+    "name": "simple-parquet",
+    "description": "Example to read Parquet files.",
+    "license": "https://creativecommons.org/licenses/by/4.0/",
+    "url": "https://mlcommons.org",
+    "distribution": [
+        {
+            "@type": "sc:FileObject",
+            "name": "dataframe",
+            "contentUrl": "data/dataframe.parquet",
+            "encodingFormat": "application/x-parquet",
+            "sha256": "SHA256"
+        }
+    ],
+    "recordSet": [
+        {
+            "@type": "ml:RecordSet",
+            "name": "persons",
+            "description": "List of persons.",
+            "field": [
+                {
+                    "@type": "ml:Field",
+                    "name": "name",
+                    "description": "Name of the person.",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "distribution": "dataframe",
+                        "extract": {
+                            "column": "name"
+                        }
+                    }
+                },
+                {
+                    "@type": "ml:Field",
+                    "name": "age",
+                    "description": "Age of the person.",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "distribution": "dataframe",
+                        "extract": {
+                            "column": "age"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/pkg/croissant/testdata/1.0/good/titanic.jsonld
+++ b/pkg/croissant/testdata/1.0/good/titanic.jsonld
@@ -1,0 +1,428 @@
+{
+    "@context": {
+        "@language": "en",
+        "@vocab": "https://schema.org/",
+        "citeAs": "cr:citeAs",
+        "column": "cr:column",
+        "conformsTo": "dct:conformsTo",
+        "cr": "http://mlcommons.org/croissant/",
+        "rai": "http://mlcommons.org/croissant/RAI/",
+        "data": {
+            "@id": "cr:data",
+            "@type": "@json"
+        },
+        "dataType": {
+            "@id": "cr:dataType",
+            "@type": "@vocab"
+        },
+        "dct": "http://purl.org/dc/terms/",
+        "examples": {
+            "@id": "cr:examples",
+            "@type": "@json"
+        },
+        "extract": "cr:extract",
+        "field": "cr:field",
+        "fileProperty": "cr:fileProperty",
+        "fileObject": "cr:fileObject",
+        "fileSet": "cr:fileSet",
+        "format": "cr:format",
+        "includes": "cr:includes",
+        "isLiveDataset": "cr:isLiveDataset",
+        "jsonPath": "cr:jsonPath",
+        "key": "cr:key",
+        "md5": "cr:md5",
+        "parentField": "cr:parentField",
+        "path": "cr:path",
+        "recordSet": "cr:recordSet",
+        "references": "cr:references",
+        "regex": "cr:regex",
+        "repeated": "cr:repeated",
+        "replace": "cr:replace",
+        "sc": "https://schema.org/",
+        "separator": "cr:separator",
+        "source": "cr:source",
+        "subField": "cr:subField",
+        "transform": "cr:transform",
+        "wd": "https://www.wikidata.org/wiki/"
+    },
+    "@type": "sc:Dataset",
+    "name": "Titanic",
+    "description": "The original Titanic dataset, describing the status of individual passengers on the Titanic.\n\n The titanic data does not contain information from the crew, but it does contain actual ages of half of the passengers. \n\n For more information about how this dataset was constructed: \nhttps://web.archive.org/web/20200802155940/http://biostat.mc.vanderbilt.edu/wiki/pub/Main/DataSets/titanic3info.txt\n\nOther useful information (useful for prices description for example):\nhttp://campus.lakeforest.edu/frank/FILES/MLFfiles/Bio150/Titanic/TitanicMETA.pdf\n\n Also see the following article describing shortcomings of the dataset data:\nhttps://emma-stiefel.medium.com/plugging-holes-in-kaggles-titanic-dataset-an-introduction-to-combining-datasets-with-fuzzywuzzy-60a686699da7\n",
+    "conformsTo": "http://mlcommons.org/croissant/1.0",
+    "citeAs": "The principal source for data about Titanic passengers is the Encyclopedia Titanica (http://www.encyclopedia-titanica.org/). The datasets used here were begun by a variety of researchers. One of the original sources is Eaton & Haas (1994) Titanic: Triumph and Tragedy, Patrick Stephens Ltd, which includes a passenger list created by many researchers and edited by Michael A. Findlay.\n\nThomas Cason of UVa has greatly updated and improved the titanic data frame using the Encyclopedia Titanica and created the dataset here. Some duplicate passengers have been dropped, many errors corrected, many missing ages filled in, and new variables created.\n",
+    "license": "afl-3.0",
+    "url": "https://www.openml.org/d/40945",
+    "version": "1.0.0",
+    "distribution": [
+        {
+            "@type": "cr:FileObject",
+            "@id": "passengers.csv",
+            "name": "passengers.csv",
+            "contentSize": "117743 B",
+            "contentUrl": "data/titanic.csv",
+            "encodingFormat": "text/csv",
+            "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
+        },
+        {
+            "@type": "cr:FileObject",
+            "@id": "genders.csv",
+            "name": "genders.csv",
+            "description": "Maps gender values (\"male\", \"female\") to semantic URLs.",
+            "contentSize": "117743 B",
+            "contentUrl": "data/genders.csv",
+            "encodingFormat": "text/csv",
+            "sha256": "3b0d1ce9ffb5224626105c50a0f9e5fbf941bcbcd913e5567aba25936333c3b8"
+        },
+        {
+            "@type": "cr:FileObject",
+            "@id": "embarkation_ports.csv",
+            "name": "embarkation_ports.csv",
+            "description": "Maps Embarkation port initial to labeled values.",
+            "contentSize": "117743 B",
+            "contentUrl": "data/embarkation_ports.csv",
+            "encodingFormat": "text/csv",
+            "sha256": "38dc364ac098f39ecb5c108c8911ef47a7256a146aef3c26c85e7cc01efdd047"
+        }
+    ],
+    "recordSet": [
+        {
+            "@type": "cr:RecordSet",
+            "@id": "genders",
+            "name": "genders",
+            "description": "Maps gender labels to semantic definitions.",
+            "dataType": "sc:Enumeration",
+            "key": {
+                "@id": "genders/label"
+            },
+            "field": [
+                {
+                    "@type": "cr:Field",
+                    "@id": "genders/label",
+                    "name": "genders/label",
+                    "description": "One of {\"male\", \"female\"}",
+                    "dataType": [
+                        "sc:Text",
+                        "sc:name"
+                    ],
+                    "source": {
+                        "fileObject": {
+                            "@id": "genders.csv"
+                        },
+                        "extract": {
+                            "column": "label"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "genders/url",
+                    "name": "genders/url",
+                    "description": "Corresponding WikiData URL",
+                    "dataType": [
+                        "sc:URL",
+                        "wd:Q48277"
+                    ],
+                    "source": {
+                        "fileObject": {
+                            "@id": "genders.csv"
+                        },
+                        "extract": {
+                            "column": "url"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "@type": "cr:RecordSet",
+            "@id": "embarkation_ports",
+            "name": "embarkation_ports",
+            "description": "Maps Embarkation port initial to labeled values.",
+            "dataType": "sc:Enumeration",
+            "key": {
+                "@id": "embarkation_ports/key"
+            },
+            "field": [
+                {
+                    "@type": "cr:Field",
+                    "@id": "embarkation_ports/key",
+                    "name": "embarkation_ports/key",
+                    "description": "C, Q, S or ?",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "fileObject": {
+                            "@id": "embarkation_ports.csv"
+                        },
+                        "extract": {
+                            "column": "key"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "embarkation_ports/label",
+                    "name": "embarkation_ports/label",
+                    "description": "Human-readable label",
+                    "dataType": [
+                        "sc:Text",
+                        "sc:name"
+                    ],
+                    "source": {
+                        "fileObject": {
+                            "@id": "embarkation_ports.csv"
+                        },
+                        "extract": {
+                            "column": "label"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "embarkation_ports/url",
+                    "name": "embarkation_ports/url",
+                    "description": "Corresponding WikiData URL",
+                    "dataType": [
+                        "sc:URL",
+                        "wd:Q515"
+                    ],
+                    "source": {
+                        "fileObject": {
+                            "@id": "embarkation_ports.csv"
+                        },
+                        "extract": {
+                            "column": "url"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "@type": "cr:RecordSet",
+            "@id": "passengers",
+            "name": "passengers",
+            "description": "The list of passengers. Does not include crew members.",
+            "field": [
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/name",
+                    "name": "passengers/name",
+                    "description": "Name of the passenger",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "name"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/gender",
+                    "name": "passengers/gender",
+                    "description": "Gender of passenger (male or female)",
+                    "dataType": "sc:Text",
+                    "references": {
+                        "field": {
+                            "@id": "genders/label"
+                        }
+                    },
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "sex"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/age",
+                    "name": "passengers/age",
+                    "description": "Age of passenger at time of death. It's a string, because some values can be `?`.",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "age"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/survived",
+                    "name": "passengers/survived",
+                    "description": "Survival status of passenger (0: Lost, 1: Saved)",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "survived"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/pclass",
+                    "name": "passengers/pclass",
+                    "description": "Passenger Class (1st/2nd/3rd)",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "pclass"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/cabin",
+                    "name": "passengers/cabin",
+                    "description": "Passenger cabin.",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "cabin"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/embarked",
+                    "name": "passengers/embarked",
+                    "description": "Port of Embarkation (C: Cherbourg, Q: Queenstown, S: Southampton, ?: Unknown).",
+                    "dataType": "sc:Text",
+                    "references": {
+                        "field": {
+                            "@id": "embarkation_ports/key"
+                        }
+                    },
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "embarked"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/fare",
+                    "name": "passengers/fare",
+                    "description": "Passenger Fare (British pound). It's a string, because some values can be `?`.",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "fare"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/home_destination",
+                    "name": "passengers/home_destination",
+                    "description": "Home and destination",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "home.dest"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/ticket",
+                    "name": "passengers/ticket",
+                    "description": "Ticket Number, may include a letter.",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "ticket"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/num_parents_children",
+                    "name": "passengers/num_parents_children",
+                    "description": "Number of Parents/Children Aboard",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "parch"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/num_siblings_spouses",
+                    "name": "passengers/num_siblings_spouses",
+                    "description": "Number of Siblings/Spouses Aboard",
+                    "dataType": "sc:Integer",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "sibsp"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/boat",
+                    "name": "passengers/boat",
+                    "description": "Lifeboat used by passenger",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "boat"
+                        }
+                    }
+                },
+                {
+                    "@type": "cr:Field",
+                    "@id": "passengers/body",
+                    "name": "passengers/body",
+                    "description": "Body Identification Number",
+                    "dataType": "sc:Text",
+                    "source": {
+                        "fileObject": {
+                            "@id": "passengers.csv"
+                        },
+                        "extract": {
+                            "column": "body"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/pkg/croissant/validation_test.go
+++ b/pkg/croissant/validation_test.go
@@ -1,0 +1,60 @@
+// File: pkg/croissant/validation_test.go
+package croissant
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateGoodCroissantFilesInDir(t *testing.T) {
+	testDir := "testdata/1.0/good"
+	files, err := os.ReadDir(testDir)
+	if err != nil {
+		t.Skip("Skipping directory test; " + testDir + " does not exist")
+
+		return
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		if filepath.Ext(file.Name()) == ".jsonld" {
+			t.Run(file.Name(), func(t *testing.T) {
+				issues, err := ValidateFile(filepath.Join(testDir, file.Name()))
+				if err != nil {
+					t.Fatalf("Failed to load croissant file %s: %v", file.Name(), err)
+				}
+				if issues.HasErrors() {
+					t.Fatalf("Croissant file has errors: %s", issues.Report())
+				}
+			})
+		}
+	}
+}
+
+func TestValidateBadCroissantFilesInDir(t *testing.T) {
+	testDir := "testdata/1.0/bad"
+	files, err := os.ReadDir(testDir)
+	if err != nil {
+		t.Skip("Skipping directory test; " + testDir + " does not exist")
+
+		return
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		if filepath.Ext(file.Name()) == ".jsonld" {
+			t.Run(file.Name(), func(t *testing.T) {
+				issues, err := ValidateFile(filepath.Join(testDir, file.Name()))
+				if err != nil {
+					t.Fatalf("Failed to load croissant file %s: %v", file.Name(), err)
+				}
+				if !issues.HasErrors() {
+					t.Fatalf("Croissant file has errors: %s", issues.Report())
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Added some tests for metadata infering and validation.

I added tests data from the samples directory, separating by version and good/bad.
The validation tests reference these files.

Right now a few of the validation are failing, but it will give us something to compare changes against.

current fail output:

```
--- FAIL: TestValidateGoodCroissantFilesInDir (0.01s)
    --- FAIL: TestValidateGoodCroissantFilesInDir/coco2014-mini.jsonld (0.00s)
        validation_test.go:29: Croissant file has errors: Found the following 9 error(s) during the validation:
              -  [Metadata(Mini-COCO) > FileObject(image-files)] Property "https://schema.org/contentUrl" is mandatory, but does not exist.
              -  [Metadata(Mini-COCO) > RecordSet(captions)] Key references non-existent field "id"
              -  [Metadata(Mini-COCO) > RecordSet(images) > Field(images/image_content)] Field "images/image_content" has invalid or missing source configuration.
              -  [Metadata(Mini-COCO) > RecordSet(images) > Field(images/image_filename)] Field "images/image_filename" has invalid or missing source configuration.
              -  [Metadata(Mini-COCO) > RecordSet(images) > Field(images/split)] Field "images/split" has invalid or missing source configuration.
              -  [Metadata(Mini-COCO) > RecordSet(images)] Key references non-existent field "img_id"
              -  [Metadata(Mini-COCO) > RecordSet(split_enums) > Field(split_enums/name)] Field "split_enums/name" has invalid or missing source configuration.
              -  [Metadata(Mini-COCO) > RecordSet(split_enums) > Field(split_enums/url)] Field "split_enums/url" has invalid or missing source configuration.
              -  [Metadata(Mini-COCO) > RecordSet(split_enums)] Key references non-existent field "name"
            
            Found the following 4 warning(s) during the validation:
              -  [Metadata(Mini-COCO) > FileObject(image-files)] SHA256 hash is recommended for file integrity verification.
              -  [Metadata(Mini-COCO) > RecordSet(captions) > Field(captions/split)] Field "captions/split" is missing recommended "description" property.
              -  [Metadata(Mini-COCO) > RecordSet(images) > Field(images/split)] Field "images/split" is missing recommended "description" property.
              -  [Metadata(Mini-COCO)] Date published is recommended for dataset tracking.
    --- FAIL: TestValidateGoodCroissantFilesInDir/ok1.jsonld (0.00s)
        validation_test.go:29: Croissant file has errors: Found the following 2 error(s) during the validation:
              -  [Metadata(data_dataset) > RecordSet(main) > Field(precipitation)] Field "precipitation" has invalid dataType "sc:Float". Valid types include: sc:Text, sc:Number, sc:Boolean, sc:DateTime, sc:URL, sc:GeoCoordinates, sc:ImageObject, cr:BoundingBox, etc.
              -  [Metadata(data_dataset) > RecordSet(main) > Field(water_flow_rate)] Field "water_flow_rate" has invalid dataType "sc:Float". Valid types include: sc:Text, sc:Number, sc:Boolean, sc:DateTime, sc:URL, sc:GeoCoordinates, sc:ImageObject, cr:BoundingBox, etc.
    --- FAIL: TestValidateGoodCroissantFilesInDir/ok3.jsonld (0.00s)
        validation_test.go:29: Croissant file has errors: Found the following 2 error(s) during the validation:
              -  [Metadata(data_dataset) > RecordSet(main) > Field(precipitation)] Field "precipitation" has invalid dataType "sc:Float". Valid types include: sc:Text, sc:Number, sc:Boolean, sc:DateTime, sc:URL, sc:GeoCoordinates, sc:ImageObject, cr:BoundingBox, etc.
              -  [Metadata(data_dataset) > RecordSet(main) > Field(water_flow_rate)] Field "water_flow_rate" has invalid dataType "sc:Float". Valid types include: sc:Text, sc:Number, sc:Boolean, sc:DateTime, sc:URL, sc:GeoCoordinates, sc:ImageObject, cr:BoundingBox, etc.
    --- FAIL: TestValidateGoodCroissantFilesInDir/simple_parquet.jsonld (0.00s)
        validation_test.go:29: Croissant file has errors: Found the following 7 error(s) during the validation:
              -  [Metadata(simple-parquet) > FileObject(dataframe)] "dataframe" should have an attribute "@type": "http://mlcommons.org/croissant/FileObject" or "@type": "http://mlcommons.org/croissant/FileSet". Got sc:FileObject instead.
              -  [Metadata(simple-parquet) > FileObject(dataframe)] SHA256 hash "SHA256" is not a valid SHA-256 hash.
              -  [Metadata(simple-parquet) > RecordSet(persons) > Field(age)] "age" should have an attribute "@type": "http://mlcommons.org/croissant/Field". Got ml:Field instead.
              -  [Metadata(simple-parquet) > RecordSet(persons) > Field(age)] Field "age" has invalid or missing source configuration.
              -  [Metadata(simple-parquet) > RecordSet(persons) > Field(name)] "name" should have an attribute "@type": "http://mlcommons.org/croissant/Field". Got ml:Field instead.
              -  [Metadata(simple-parquet) > RecordSet(persons) > Field(name)] Field "name" has invalid or missing source configuration.
              -  [Metadata(simple-parquet) > RecordSet(persons)] "persons" should have an attribute "@type": "http://mlcommons.org/croissant/RecordSet". Got ml:RecordSet instead.
            
            Found the following 3 warning(s) during the validation:
              -  [Metadata(simple-parquet)] Dataset version is recommended for proper versioning.
              -  [Metadata(simple-parquet)] Date published is recommended for dataset tracking.
              -  [Metadata(simple-parquet)] Property "http://purl.org/dc/terms/conformsTo" is recommended, but does not exist.
    --- FAIL: TestValidateGoodCroissantFilesInDir/titanic.jsonld (0.00s)
        validation_test.go:29: Croissant file has errors: Found the following 2 error(s) during the validation:
              -  [Metadata(Titanic) > RecordSet(embarkation_ports) > Field(embarkation_ports/label)] Field "embarkation_ports/label" has invalid dataType "sc:name". Valid types include: sc:Text, sc:Number, sc:Boolean, sc:DateTime, sc:URL, sc:GeoCoordinates, sc:ImageObject, cr:BoundingBox, etc.
              -  [Metadata(Titanic) > RecordSet(genders) > Field(genders/label)] Field "genders/label" has invalid dataType "sc:name". Valid types include: sc:Text, sc:Number, sc:Boolean, sc:DateTime, sc:URL, sc:GeoCoordinates, sc:ImageObject, cr:BoundingBox, etc.
            
            Found the following 1 warning(s) during the validation:
              -  [Metadata(Titanic)] Date published is recommended for dataset tracking.
```


