### PR TITLE
Add sc:Float as a valid croissant type

### DIFF
--- a/pkg/croissant/croissant.go
+++ b/pkg/croissant/croissant.go
@@ -190,6 +190,7 @@ func IsValidDataType(dataType string) bool {
 		"sc:Boolean":        true,
 		"sc:Integer":        true,
 		"sc:Number":         true,
+		"sc:Float":          true, // Infers to sc:Number
 		"sc:DateTime":       true,
 		"sc:URL":            true,
 		"sc:ImageObject":    true,


### PR DESCRIPTION
Floats will still be "Infer"ed into an `sc:Number` type, but this will detect `sc:Float` types as valid.

When writing a croissant file, it will continue to use `sc:Number` for float values.